### PR TITLE
feat: implement tab update and schema aggregation

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -424,6 +424,50 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   }
 });
 
+// Notify sidepanel when user switches tabs
+chrome.tabs.onActivated.addListener(({ tabId }) => {
+  const cached = tabDataCache.get(tabId);
+  const aggregation = tabAggregationState.get(tabId) || null;
+  const nlweb = tabNlwebState.get(tabId) || null;
+
+  chrome.runtime
+    .sendMessage({
+      type: "TAB_ACTIVATED",
+      payload: cached || null,
+      aggregation,
+      nlweb: nlweb?.endpoint ? { endpoint: nlweb.endpoint, method: "cached" } : null,
+      tabId,
+    })
+    .catch(() => {});
+
+  // If no cached data, ask the content script to extract
+  if (!cached) {
+    chrome.tabs.sendMessage(tabId, { type: "REQUEST_EXTRACTION" }, () => {
+      if (chrome.runtime.lastError) {
+        // Content script not injected — inject it, then request extraction
+        chrome.scripting
+          .executeScript({
+            target: { tabId },
+            files: [
+              "content/nlweb-discovery.js",
+              "content/schema-aggregation.js",
+              "content/extractor.js",
+              "content/schemamap.js",
+              "content/transformer.js",
+              "content/presets/presets.js",
+            ],
+          })
+          .then(() => {
+            chrome.tabs.sendMessage(tabId, { type: "REQUEST_EXTRACTION" }, () => {
+              if (chrome.runtime.lastError) { /* still failed — ignore */ }
+            });
+          })
+          .catch(() => { /* chrome:// or other restricted page — ignore */ });
+      }
+    });
+  }
+});
+
 // Clean up on tab close
 chrome.tabs.onRemoved.addListener((tabId) => {
   if (tabId === micSetupTabId) {

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -378,6 +378,16 @@ import {
 
   // Listen for live updates
   chrome.runtime.onMessage.addListener((message) => {
+    if (message.type === 'TAB_ACTIVATED') {
+      handleSchemaData(message.payload);
+      isTransformActive = false;
+      btnActivate.hidden = false;
+      btnDeactivate.hidden = true;
+      showAggregationSection(message.aggregation);
+      if (message.nlweb) {
+        updateNlwebSection(message.nlweb.endpoint, message.nlweb.method);
+      }
+    }
     if (message.type === 'SCHEMA_UPDATE') {
       handleSchemaData(message.payload);
     }


### PR DESCRIPTION
## Summary
- Add schema aggregation support: client, content script probe, and sidepanel UI section with paginated product browsing
- Refactor service worker message handlers into a named-function registry with event delegation
- Update sidepanel when the user switches tabs, sending cached data and triggering extraction when needed
- Add buy-product button from offer URLs

## Test plan
- [ ] Switch between tabs and verify the sidepanel updates with the correct schema data
- [ ] Visit a site with Yoast schema aggregation and confirm products are fetched and paginated
- [ ] Verify the buy button appears when offer URLs are present
- [ ] Confirm content script injection works on tabs opened before the extension loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)