### PR TITLE
Fix: Extract URLs from href in RDFa Breadcrumb elements

### DIFF
--- a/content/extractor.js
+++ b/content/extractor.js
@@ -122,7 +122,7 @@ function parseRdfaItem(element) {
   if (vocab) {
     item['@vocab'] = vocab;
   }
-  // RDFa resource attribute functions as an @id
+  // RDFa resource (or href for A/LINK) functions as an @id
   let resource = element.getAttribute('resource');
   if (!resource && (element.tagName === 'A' || element.tagName === 'LINK')) {
     resource = element.getAttribute('href');


### PR DESCRIPTION
Resolves an issue where BreadcrumbList items defined via RDFa would fail to generate clickable anchor tags because the extractor ignored `href` attributes if a `typeof` attribute was present. Now correctly maps `href` to `@id` representing the entity's URI.