### PR TITLE
feat: add auto-theme support and cross-tab state synchronization

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -327,6 +327,23 @@ function handleSetIconState(message) {
 }
 
 // Handler registry — maps message types to handler functions
+
+function handleGetTabState(message, sender, sendResponse) {
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    if (tabs[0]) {
+      chrome.tabs.sendMessage(tabs[0].id, { type: "GET_STATE" }, (response) => {
+        if (chrome.runtime.lastError) {
+          sendResponse(null);
+        } else {
+          sendResponse(response || null);
+        }
+      });
+    } else {
+      sendResponse(null);
+    }
+  });
+  return true;
+}
 const handlers = {
   SCHEMA_DATA: handleSchemaData,
   GET_SCHEMA_DATA: handleGetSchemaData,
@@ -344,6 +361,7 @@ const handlers = {
   SET_DYSLEXIA: handleSetDyslexia,
   SET_THEME: handleSetTheme,
   SET_ICON_STATE: handleSetIconState,
+  GET_TAB_STATE: handleGetTabState,
   GET_SCHEMAMAP: handleGetSchemamap,
 };
 

--- a/content/presets/presets.js
+++ b/content/presets/presets.js
@@ -1,9 +1,10 @@
 // Accessibility Preset Manager (v3)
 // low-vision.css is ALWAYS injected when the overlay is active (base accessible styles)
-//   → Light mode = higher contrast (#FAFAFA/#333, 12.10:1 AAA)
+//   → Light mode = higher contrast (#FAFAFA/#222, AAA)
 //   → Dark mode = softer contrast for comfortable reading
 // dyslexia.css is the only toggleable preset (font, size & spacing — no colors)
 // Persists state via chrome.storage.local
+// Supports 'auto' theme that follows OS preference
 
 (function () {
   'use strict';
@@ -14,7 +15,7 @@
   const DYSLEXIA_CSS = 'content/presets/dyslexia.css';
 
   let dyslexiaEnabled = false;
-  let currentTheme = 'light';
+  let currentTheme = 'auto';
 
   function isContextValid() {
     try {
@@ -22,6 +23,13 @@
     } catch {
       return false;
     }
+  }
+
+  function resolveEffectiveTheme(theme) {
+    if (theme === 'auto') {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    return theme;
   }
 
   function injectStylesheet(id, cssPath) {
@@ -46,8 +54,9 @@
     const overlay = document.getElementById('ua-accessible-overlay');
     if (!overlay) return;
 
-    // Apply theme to overlay
-    if (currentTheme === 'dark') {
+    // Apply theme to overlay (resolve 'auto' to effective theme)
+    const effective = resolveEffectiveTheme(currentTheme);
+    if (effective === 'dark') {
       overlay.setAttribute('data-theme', 'dark');
     } else {
       overlay.removeAttribute('data-theme');
@@ -74,16 +83,27 @@
     }
   }
 
+  // --- Re-apply theme when OS preference changes (only matters in auto mode) ---
+  try {
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+      if (currentTheme === 'auto') {
+        applyState();
+      }
+    });
+  } catch {
+    // matchMedia not available
+  }
+
   // --- Restore on load (with migration from v1/v2 formats) ---
   try {
     chrome.storage.local.get(['uaPreset', 'uaPresets', 'uaDyslexia', 'uaTheme'], (result) => {
       if (chrome.runtime.lastError) return;
 
-      // Restore theme
-      if (result.uaTheme === 'dark' || result.uaTheme === 'light') {
+      // Restore theme (now supports 'auto')
+      if (result.uaTheme === 'dark' || result.uaTheme === 'light' || result.uaTheme === 'auto') {
         currentTheme = result.uaTheme;
       } else {
-        currentTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        currentTheme = 'auto';
       }
 
       // v3 format
@@ -133,11 +153,45 @@
           sendResponse({ presets: { dyslexia: dyslexiaEnabled } });
         }
 
-        // Set theme (light/dark)
+        // Set theme (light/dark/auto)
         if (message.type === 'SET_THEME') {
-          currentTheme = message.theme === 'dark' ? 'dark' : 'light';
+          currentTheme = (message.theme === 'dark' || message.theme === 'light' || message.theme === 'auto')
+            ? message.theme : 'auto';
           applyState();
           sendResponse({ success: true, theme: currentTheme });
+        }
+
+        // Get full state (for sidepanel sync on tab switch)
+        // Re-reads from storage first so we pick up changes made from other tabs
+        if (message.type === 'GET_STATE') {
+          chrome.storage.local.get(['uaPresets', 'uaTheme'], (result) => {
+            if (chrome.runtime.lastError) {
+              sendResponse({
+                theme: currentTheme,
+                presets: { dyslexia: dyslexiaEnabled },
+                overlayActive: !!document.getElementById('ua-accessible-overlay')
+              });
+              return;
+            }
+
+            // Sync from storage (other tab may have changed these)
+            if (result.uaTheme === 'dark' || result.uaTheme === 'light' || result.uaTheme === 'auto') {
+              currentTheme = result.uaTheme;
+            }
+            if (result.uaPresets && typeof result.uaPresets === 'object') {
+              dyslexiaEnabled = !!result.uaPresets.dyslexia;
+            }
+
+            // Re-apply to overlay if present
+            applyState();
+
+            sendResponse({
+              theme: currentTheme,
+              presets: { dyslexia: dyslexiaEnabled },
+              overlayActive: !!document.getElementById('ua-accessible-overlay')
+            });
+          });
+          return true; // async sendResponse
         }
 
         // --- Backward compatibility ---

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -62,8 +62,8 @@ import {
     document.getElementById('seg-theme-dark')?.classList.toggle('active', theme === 'dark');
     document.getElementById('seg-theme-dark')?.setAttribute('aria-checked', String(theme === 'dark'));
     chrome.storage.local.set({ uaTheme: theme });
-    // Send effective theme to content script overlay
-    chrome.runtime.sendMessage({ type: 'SET_THEME', theme: effective });
+    // Send raw theme to content script (content script resolves 'auto' itself)
+    chrome.runtime.sendMessage({ type: 'SET_THEME', theme: theme });
   }
 
   // Re-apply when OS preference changes (only matters in auto mode)
@@ -319,6 +319,48 @@ import {
     }
   });
 
+  // --- Sync state from active tab (called on tab switch / page load) ---
+
+  function syncStateFromTab() {
+    chrome.runtime.sendMessage({ type: 'GET_TAB_STATE' }, (response) => {
+      if (chrome.runtime.lastError || !response) return;
+
+      // Sync theme (update UI only — don't re-send to content script)
+      if (response.theme === 'dark' || response.theme === 'light' || response.theme === 'auto') {
+        currentTheme = response.theme;
+        const effective = resolveEffectiveTheme(response.theme);
+        if (effective === 'dark') {
+          document.body.setAttribute('data-theme', 'dark');
+        } else {
+          document.body.removeAttribute('data-theme');
+        }
+        document.getElementById('seg-theme-auto')?.classList.toggle('active', response.theme === 'auto');
+        document.getElementById('seg-theme-auto')?.setAttribute('aria-checked', String(response.theme === 'auto'));
+        document.getElementById('seg-theme-light')?.classList.toggle('active', response.theme === 'light');
+        document.getElementById('seg-theme-light')?.setAttribute('aria-checked', String(response.theme === 'light'));
+        document.getElementById('seg-theme-dark')?.classList.toggle('active', response.theme === 'dark');
+        document.getElementById('seg-theme-dark')?.setAttribute('aria-checked', String(response.theme === 'dark'));
+      }
+
+      // Sync dyslexia (update UI only — don't re-send to content script)
+      if (response.presets) {
+        dyslexiaEnabled = !!response.presets.dyslexia;
+        const toggle = document.getElementById('toggle-dyslexia');
+        if (toggle) toggle.setAttribute('aria-checked', String(dyslexiaEnabled));
+        document.body.classList.toggle('sp-preset-dyslexia', dyslexiaEnabled);
+      }
+
+      // Sync overlay activation state
+      if (response.overlayActive) {
+        isTransformActive = true;
+        setTransformToggle(true);
+      } else {
+        isTransformActive = false;
+        setTransformToggle(false);
+      }
+    });
+  }
+
   // --- Raw Data Tree Rendering ---
 
   function renderSection(sectionId, items, isJsonLd = false) {
@@ -449,6 +491,7 @@ import {
 
       if (changeInfo.status === 'complete') {
         refreshSchemaData();
+        syncStateFromTab();
       }
     });
   });
@@ -456,12 +499,12 @@ import {
   // Listen for live updates
   chrome.runtime.onMessage.addListener((message) => {
     if (message.type === 'TAB_ACTIVATED') {
-      setTransformToggle(false);
       handleSchemaData(message.payload);
       showAggregationSection(message.aggregation);
       if (message.nlweb) {
         updateNlwebSection(message.nlweb.endpoint, message.nlweb.method);
       }
+      syncStateFromTab();
     }
     if (message.type === 'SCHEMA_UPDATE') {
       handleSchemaData(message.payload);


### PR DESCRIPTION
Adds 'auto' theme mode that follows OS dark/light preference, and synchronizes theme, dyslexia, and overlay state across tabs.

### Changes
- **`content/presets/presets.js`**: Auto-theme support, `resolveEffectiveTheme()`, `matchMedia` listener, `GET_STATE` handler
- **`background/service-worker.js`**: New `GET_TAB_STATE` handler
- **`sidepanel/sidepanel.js`**: `syncStateFromTab()`, sends raw theme to content script