### PR TITLE
Fix toolbar icons failing to fetch in MV3 service worker

### DIFF
--- a/background/badge.js
+++ b/background/badge.js
@@ -1,38 +1,71 @@
 // Toolbar icon state management
+// Uses ImageData instead of path strings to avoid the Chrome MV3 service worker
+// "Failed to fetch" bug: https://issues.chromium.org/issues/40884749
 
 const ICON_PATHS = {
   'off': {
-    '16': 'icons/icon-off-16.png',
-    '48': 'icons/icon-off-48.png',
-    '128': 'icons/icon-off-128.png'
+    16: 'icons/icon-off-16.png',
+    48: 'icons/icon-off-48.png',
+    128: 'icons/icon-off-128.png'
   },
   'on': {
-    '16': 'icons/icon-on-16.png',
-    '48': 'icons/icon-on-48.png',
-    '128': 'icons/icon-on-128.png'
+    16: 'icons/icon-on-16.png',
+    48: 'icons/icon-on-48.png',
+    128: 'icons/icon-on-128.png'
   },
   'detection-no': {
-    '16': 'icons/icon-detection-no-16.png',
-    '48': 'icons/icon-detection-no-48.png',
-    '128': 'icons/icon-detection-no-128.png'
+    16: 'icons/icon-detection-no-16.png',
+    48: 'icons/icon-detection-no-48.png',
+    128: 'icons/icon-detection-no-128.png'
   },
   'detection-yes': {
-    '16': 'icons/icon-detection-yes-16.png',
-    '48': 'icons/icon-detection-yes-48.png',
-    '128': 'icons/icon-detection-yes-128.png'
+    16: 'icons/icon-detection-yes-16.png',
+    48: 'icons/icon-detection-yes-48.png',
+    128: 'icons/icon-detection-yes-128.png'
   }
 };
 
-export function updateToolbarIcon(tabId, state) {
+const imageDataCache = new Map();
+
+export function clearIconCache() {
+  imageDataCache.clear();
+}
+
+async function loadIconImageData(path) {
+  const response = await fetch(chrome.runtime.getURL(path));
+  const blob = await response.blob();
+  const bitmap = await createImageBitmap(blob);
+  const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(bitmap, 0, 0);
+  bitmap.close();
+  return ctx.getImageData(0, 0, bitmap.width, bitmap.height);
+}
+
+async function getIconImageData(state) {
+  if (imageDataCache.has(state)) return imageDataCache.get(state);
+
   const paths = ICON_PATHS[state];
-  if (!paths) return;
-  if (tabId) {
-    chrome.action.setIcon({ path: paths, tabId }).catch((err) => {
-      console.warn('[Universal Access] setIcon failed:', err.message, { state, tabId });
-    });
-  } else {
-    chrome.action.setIcon({ path: paths }).catch((err) => {
-      console.warn('[Universal Access] setIcon failed:', err.message, { state });
-    });
+  if (!paths) return null;
+
+  const [img16, img48, img128] = await Promise.all([
+    loadIconImageData(paths[16]),
+    loadIconImageData(paths[48]),
+    loadIconImageData(paths[128]),
+  ]);
+
+  const imageData = { 16: img16, 48: img48, 128: img128 };
+  imageDataCache.set(state, imageData);
+  return imageData;
+}
+
+export async function updateToolbarIcon(tabId, state) {
+  try {
+    const imageData = await getIconImageData(state);
+    if (!imageData) return;
+    const details = tabId ? { imageData, tabId } : { imageData };
+    await chrome.action.setIcon(details);
+  } catch (err) {
+    console.warn('[Universal Access] setIcon failed:', err.message, { state, tabId });
   }
 }

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -310,19 +310,7 @@ function handleSetIconState(message) {
   if (!state) return;
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     const tabId = tabs[0]?.id;
-    const paths = {
-      'on': { '16': 'icons/icon-on-16.png', '48': 'icons/icon-on-48.png', '128': 'icons/icon-on-128.png' },
-      'detection-no': { '16': 'icons/icon-detection-no-16.png', '48': 'icons/icon-detection-no-48.png', '128': 'icons/icon-detection-no-128.png' },
-      'detection-yes': { '16': 'icons/icon-detection-yes-16.png', '48': 'icons/icon-detection-yes-48.png', '128': 'icons/icon-detection-yes-128.png' }
-    };
-    const iconPaths = paths[state];
-    if (!iconPaths) return;
-    const details = tabId ? { path: iconPaths, tabId } : { path: iconPaths };
-    chrome.action.setIcon(details).then(() => {
-      console.log('[UA] Icon set to', state, tabId ? 'for tab ' + tabId : '');
-    }).catch((err) => {
-      console.error('[UA] setIcon FAILED:', err, { state, tabId, details });
-    });
+    updateToolbarIcon(tabId, state);
   });
 }
 

--- a/tests/background/badge.test.js
+++ b/tests/background/badge.test.js
@@ -1,44 +1,72 @@
-import { describe, it, expect } from 'vitest';
-import { updateToolbarIcon } from '../../background/badge.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { updateToolbarIcon, clearIconCache } from '../../background/badge.js';
+
+// Fake ImageData returned by the mocked pipeline
+const fakeImageData = { data: new Uint8ClampedArray(4), width: 1, height: 1 };
+
+// Mock fetch → blob → createImageBitmap → OffscreenCanvas pipeline
+const mockGetImageData = vi.fn().mockReturnValue(fakeImageData);
+const mockCtx = { drawImage: vi.fn(), getImageData: mockGetImageData };
+
+beforeEach(() => {
+  clearIconCache();
+  globalThis.createImageBitmap = vi.fn().mockResolvedValue({ width: 1, height: 1, close: vi.fn() });
+  globalThis.OffscreenCanvas = vi.fn().mockImplementation(() => ({
+    getContext: vi.fn().mockReturnValue(mockCtx),
+  }));
+  globalThis.fetch = vi.fn().mockResolvedValue({ blob: vi.fn().mockResolvedValue(new Blob()) });
+  chrome.runtime.getURL = vi.fn((path) => `chrome-extension://id/${path}`);
+  mockGetImageData.mockClear();
+  mockCtx.drawImage.mockClear();
+});
 
 describe('updateToolbarIcon', () => {
-  it('sets icon paths for a valid state with tabId', () => {
-    updateToolbarIcon(1, 'on');
+  it('sets imageData for a valid state with tabId', async () => {
+    await updateToolbarIcon(1, 'on');
 
     expect(chrome.action.setIcon).toHaveBeenCalledWith({
-      path: {
-        '16': 'icons/icon-on-16.png',
-        '48': 'icons/icon-on-48.png',
-        '128': 'icons/icon-on-128.png',
-      },
+      imageData: { 16: fakeImageData, 48: fakeImageData, 128: fakeImageData },
       tabId: 1,
     });
   });
 
-  it('sets icon without tabId when tabId is falsy', () => {
-    updateToolbarIcon(null, 'detection-yes');
+  it('sets imageData without tabId when tabId is falsy', async () => {
+    await updateToolbarIcon(null, 'detection-yes');
 
     expect(chrome.action.setIcon).toHaveBeenCalledWith({
-      path: {
-        '16': 'icons/icon-detection-yes-16.png',
-        '48': 'icons/icon-detection-yes-48.png',
-        '128': 'icons/icon-detection-yes-128.png',
-      },
+      imageData: { 16: fakeImageData, 48: fakeImageData, 128: fakeImageData },
     });
   });
 
-  it('does nothing for an unknown state', () => {
-    updateToolbarIcon(1, 'invalid-state');
+  it('does nothing for an unknown state', async () => {
+    await updateToolbarIcon(1, 'invalid-state');
 
     expect(chrome.action.setIcon).not.toHaveBeenCalled();
   });
 
-  it('supports all defined icon states', () => {
+  it('supports all defined icon states', async () => {
     const states = ['off', 'on', 'detection-no', 'detection-yes'];
     for (const state of states) {
       chrome.action.setIcon.mockClear();
-      updateToolbarIcon(1, state);
+      await updateToolbarIcon(1, state);
       expect(chrome.action.setIcon).toHaveBeenCalledOnce();
     }
+  });
+
+  it('fetches icons with chrome.runtime.getURL paths', async () => {
+    await updateToolbarIcon(1, 'on');
+
+    expect(chrome.runtime.getURL).toHaveBeenCalledWith('icons/icon-on-16.png');
+    expect(chrome.runtime.getURL).toHaveBeenCalledWith('icons/icon-on-48.png');
+    expect(chrome.runtime.getURL).toHaveBeenCalledWith('icons/icon-on-128.png');
+    expect(globalThis.fetch).toHaveBeenCalledWith('chrome-extension://id/icons/icon-on-16.png');
+  });
+
+  it('caches imageData and only fetches once per state', async () => {
+    await updateToolbarIcon(1, 'on');
+    await updateToolbarIcon(2, 'on');
+
+    // 3 fetches for the 3 sizes, not 6
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
## Summary
- Switch `chrome.action.setIcon` from path strings to `ImageData` rendered via `OffscreenCanvas`, avoiding the Chrome MV3 ["Failed to fetch" bug](https://issues.chromium.org/issues/40884749) that occurs when the service worker goes idle
- Add per-state `ImageData` caching so icons are only fetched/rendered once
- Remove duplicate icon-path map from `handleSetIconState` in favour of the shared `updateToolbarIcon` helper

Closes #43

## Test plan
- [ ] Verify toolbar icon updates correctly for all states (off, on, detection-no, detection-yes)
- [ ] Confirm no "Failed to fetch" errors in the service worker console after the worker idles and reactivates
- [ ] Run `npm test` — badge tests pass with the new async ImageData flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)