### PR TITLE
feat: improve speech interaction UX with audio cues and redesigned mic button

### DIFF
--- a/sidepanel/audio-cues.js
+++ b/sidepanel/audio-cues.js
@@ -1,0 +1,59 @@
+// Audio cue utilities for speech recognition feedback
+// Uses the Web Audio API to synthesize short tones — no external files needed.
+
+const AudioCues = (function () {
+  'use strict';
+
+  let audioCtx = null;
+
+  function getContext() {
+    if (!audioCtx) {
+      audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    }
+    return audioCtx;
+  }
+
+  /**
+   * Play a short frequency-sweep tone.
+   * @param {number} startHz  – starting frequency
+   * @param {number} endHz    – ending frequency
+   * @param {number} duration – length in seconds
+   * @param {number} volume   – gain (0–1)
+   */
+  function playTone(startHz, endHz, duration = 0.15, volume = 0.3) {
+    try {
+      const ctx = getContext();
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+
+      osc.type = 'sine';
+      osc.frequency.setValueAtTime(startHz, ctx.currentTime);
+      osc.frequency.linearRampToValueAtTime(endHz, ctx.currentTime + duration);
+
+      gain.gain.setValueAtTime(volume, ctx.currentTime);
+      // Fade out to avoid click
+      gain.gain.linearRampToValueAtTime(0, ctx.currentTime + duration);
+
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+
+      osc.start(ctx.currentTime);
+      osc.stop(ctx.currentTime + duration);
+    } catch (e) {
+      // AudioContext unavailable — silently ignore
+      console.warn('[audio-cues] playTone failed:', e.message);
+    }
+  }
+
+  /** Rising tone — signals voice recognition has started. */
+  function playStartCue() {
+    playTone(440, 880, 0.15, 0.25);
+  }
+
+  /** Falling tone — signals voice recognition has stopped. */
+  function playStopCue() {
+    playTone(880, 440, 0.15, 0.25);
+  }
+
+  return { playStartCue, playStopCue };
+})();

--- a/sidepanel/sidepanel.css
+++ b/sidepanel/sidepanel.css
@@ -684,24 +684,112 @@ main {
 }
 
 .nlweb-mic-btn {
+  position: relative;
   min-width: 44px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
   background: var(--sp-surface-hover);
   color: var(--sp-text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s, color 0.2s, box-shadow 0.2s, transform 0.1s;
+  padding: 0;
+  flex-shrink: 0;
 }
 
 .nlweb-mic-btn:hover {
   background: var(--sp-surface-active);
+  color: var(--sp-text);
+  transform: scale(1.05);
 }
+
+.nlweb-mic-btn:active {
+  transform: scale(0.95);
+}
+
+.nlweb-mic-btn:focus-visible {
+  outline: 2px solid var(--sp-primary);
+  outline-offset: 2px;
+}
+
+/* SVG icons inside the mic button */
+.mic-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  transition: opacity 0.15s;
+}
+
+.mic-icon-active {
+  display: none;
+}
+
+/* Pulse ring — hidden by default */
+.mic-pulse {
+  display: none;
+}
+
+/* --- Listening state --- */
 
 .nlweb-mic-btn.listening {
   background: #D93025;
   color: white;
+  box-shadow: 0 0 0 0 rgba(217, 48, 37, 0.4);
+}
+
+.nlweb-mic-btn.listening:hover {
+  background: #C5221F;
+  color: white;
+}
+
+.nlweb-mic-btn.listening .mic-icon-idle {
+  display: none;
+}
+
+.nlweb-mic-btn.listening .mic-icon-active {
+  display: block;
+}
+
+.nlweb-mic-btn.listening .mic-pulse {
+  display: block;
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  border: 2px solid rgba(217, 48, 37, 0.5);
+  animation: mic-pulse-ring 1.5s ease-out infinite;
+  pointer-events: none;
+}
+
+@keyframes mic-pulse-ring {
+  0% {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+  100% {
+    transform: scale(1.4);
+    opacity: 0;
+  }
 }
 
 .nlweb-mic-btn:disabled {
   background: var(--sp-surface-hover);
   color: var(--sp-text-hint);
   cursor: default;
+  transform: none;
+  opacity: 0.5;
+}
+
+.nlweb-mic-btn:disabled .mic-pulse {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mic-pulse {
+    animation: none !important;
+    display: none !important;
+  }
 }
 
 .nlweb-stt-status {

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -91,7 +91,11 @@
       </div>
       <form id="nlweb-form" class="nlweb-form">
         <input type="text" id="nlweb-query" placeholder="Ask this site a question..." autocomplete="off" aria-label="Ask this site a question">
-        <button type="button" id="nlweb-mic" class="nlweb-mic-btn" aria-label="Start voice input" aria-pressed="false">Mic</button>
+        <button type="button" id="nlweb-mic" class="nlweb-mic-btn" aria-label="Start voice input" aria-pressed="false">
+          <svg class="mic-icon mic-icon-idle" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" x2="12" y1="19" y2="22"/></svg>
+          <svg class="mic-icon mic-icon-active" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>
+          <span class="mic-pulse"></span>
+        </button>
         <button type="submit" id="nlweb-submit">Ask</button>
       </form>
       <div id="nlweb-stt-status" class="nlweb-stt-status" aria-live="polite"></div>
@@ -139,6 +143,7 @@
     </section>
   </main>
 
+  <script src="audio-cues.js"></script>
   <script src="speech-recognition.js"></script>
   <script type="module" src="sidepanel.js"></script>
 </body>

--- a/sidepanel/speech-recognition.js
+++ b/sidepanel/speech-recognition.js
@@ -44,7 +44,6 @@ function createSpeechRecognitionController(config = {}) {
       "aria-label",
       speechIsListening ? "Stop voice input" : "Start voice input",
     );
-    mic.textContent = speechIsListening ? "Stop" : "Mic";
   }
 
   function buildSpeechInputValue(finalTranscript, interimTranscript = "") {
@@ -254,6 +253,7 @@ function createSpeechRecognitionController(config = {}) {
       });
       updateMicButtonUi();
       updateSpeechStatus("Listening... click Stop when done.");
+      if (typeof AudioCues !== 'undefined') AudioCues.playStartCue();
     });
 
     speechRecognition.addEventListener("speechstart", () => {
@@ -363,6 +363,7 @@ function createSpeechRecognitionController(config = {}) {
 
       speechIsListening = false;
       updateMicButtonUi();
+      if (typeof AudioCues !== 'undefined') AudioCues.playStopCue();
       if (!getStatus()?.classList.contains("error")) {
         updateSpeechStatus("Voice input is off.");
       }


### PR DESCRIPTION
Closes #17

## Changes

### Audio Feedback
- Rising tone (440-880 Hz) when voice recognition starts
- Falling tone (880-440 Hz) when voice recognition stops
- Uses Web Audio API — no external audio files needed
- No sound during auto-restart (continuous listening mode)

### Mic Button Redesign
- Circular button with SVG microphone icon (idle) and stop icon (listening)
- Pulsing red ring animation when actively listening
- Smooth scale transitions on hover/press
- Proper focus-visible styles for keyboard navigation
- Respects prefers-reduced-motion for the pulse animation

### Files
- **NEW** sidepanel/audio-cues.js — Web Audio API tone utility
- **MODIFIED** sidepanel/speech-recognition.js — integrated audio cues, removed text labels
- **MODIFIED** sidepanel/sidepanel.html — SVG icon mic button markup
- **MODIFIED** sidepanel/sidepanel.css — redesigned mic button styles with pulse animation